### PR TITLE
Update chmo.Makefile to fix failing QC workflow

### DIFF
--- a/src/ontology/chmo.Makefile
+++ b/src/ontology/chmo.Makefile
@@ -6,7 +6,7 @@
 ## Module for ontology: ms
 # Using ROBOT extract MIREOT here, as CHMO only reuses one class from MS
 
-$(IMPORTDIR)/ms_import.owl: $(MIRRORDIR)/ms.owl $(IMPORTDIR)/ms_terms.txt
+$(IMPORTDIR)/ms_import.owl: $(IMPORTDIR)/ms_terms.txt
 	if [ $(IMP) = true ]; then $(ROBOT) query -i $< --update ../sparql/preprocess-module.ru \
 		extract -T $(IMPORTDIR)/ms_terms.txt --copy-ontology-annotations true --force true \
 		--upper-terms $(IMPORTDIR)/ms_terms.txt --lower-terms $(IMPORTDIR)/ms_terms.txt \
@@ -29,7 +29,7 @@ $(IMPORTDIR)/ms_import.owl: $(MIRRORDIR)/ms.owl $(IMPORTDIR)/ms_terms.txt
 # and classes used in these, which is quite a time consuming task, but needed, as ROBOT extract pulls in too much 
 # and the CHEBI module would otherwise be too big to load. 
  
-$(IMPORTDIR)/chebi_import.owl: $(MIRRORDIR)/chebi.owl $(IMPORTDIR)/chebi_terms.txt
+$(IMPORTDIR)/chebi_import.owl: $(IMPORTDIR)/chebi_terms.txt
 	if [ $(IMP) = true ] && [ $(IMP_LARGE) = true ]; then $(ROBOT) \
 	    filter -i $< -T $(IMPORTDIR)/chebi_terms.txt --signature true --select "annotations self" \
 	        --exclude-term http://purl.obolibrary.org/obo/CHEBI_24431 \
@@ -43,7 +43,7 @@ $(IMPORTDIR)/chebi_import.owl: $(MIRRORDIR)/chebi.owl $(IMPORTDIR)/chebi_terms.t
 ## We need to use the ODK default ROBOT 'extract' method plus 'filter' in here to remove out-of-scope terms that 
 ## get also pulled in. And we remove the NCBITaxon intermediates between OBI:organism and NCBITaxon:Homo Sapiens.
 
-$(IMPORTDIR)/obi_import.owl: $(MIRRORDIR)/obi.owl $(IMPORTDIR)/obi_terms.txt
+$(IMPORTDIR)/obi_import.owl: $(IMPORTDIR)/obi_terms.txt
 	if [ $(IMP) = true ]; then $(ROBOT) query -i $< --update ../sparql/preprocess-module.ru \
 		extract -T $(IMPORTDIR)/obi_terms.txt --copy-ontology-annotations true --force true \
 		    --individuals include --method BOT \

--- a/src/ontology/chmo.Makefile
+++ b/src/ontology/chmo.Makefile
@@ -6,10 +6,10 @@
 ## Module for ontology: ms
 # Using ROBOT extract MIREOT here, as CHMO only reuses one class from MS
 
-$(IMPORTDIR)/ms_import.owl: $(MIRRORDIR)/ms.owl $(IMPORTDIR)/ms_terms_combined.txt
+$(IMPORTDIR)/ms_import.owl: $(MIRRORDIR)/ms.owl $(IMPORTDIR)/ms_terms.txt
 	if [ $(IMP) = true ]; then $(ROBOT) query -i $< --update ../sparql/preprocess-module.ru \
-		extract -T $(IMPORTDIR)/ms_terms_combined.txt --copy-ontology-annotations true --force true \
-		--upper-terms $(IMPORTDIR)/ms_terms_combined.txt --lower-terms $(IMPORTDIR)/ms_terms_combined.txt \
+		extract -T $(IMPORTDIR)/ms_terms.txt --copy-ontology-annotations true --force true \
+		--upper-terms $(IMPORTDIR)/ms_terms.txt --lower-terms $(IMPORTDIR)/ms_terms.txt \
 		--individuals include --method MIREOT \
 		query --update ../sparql/inject-subset-declaration.ru --update ../sparql/inject-synonymtype-declaration.ru --update ../sparql/postprocess-module.ru \
 		$(ANNOTATE_CONVERT_FILE); fi
@@ -29,9 +29,9 @@ $(IMPORTDIR)/ms_import.owl: $(MIRRORDIR)/ms.owl $(IMPORTDIR)/ms_terms_combined.t
 # and classes used in these, which is quite a time consuming task, but needed, as ROBOT extract pulls in too much 
 # and the CHEBI module would otherwise be too big to load. 
  
-$(IMPORTDIR)/chebi_import.owl: $(MIRRORDIR)/chebi.owl $(IMPORTDIR)/chebi_terms_combined.txt
+$(IMPORTDIR)/chebi_import.owl: $(MIRRORDIR)/chebi.owl $(IMPORTDIR)/chebi_terms.txt
 	if [ $(IMP) = true ] && [ $(IMP_LARGE) = true ]; then $(ROBOT) \
-	    filter -i $< -T $(IMPORTDIR)/chebi_terms_combined.txt --signature true --select "annotations self" \
+	    filter -i $< -T $(IMPORTDIR)/chebi_terms.txt --signature true --select "annotations self" \
 	        --exclude-term http://purl.obolibrary.org/obo/CHEBI_24431 \
 	        --exclude-term http://purl.obolibrary.org/obo/CHEBI_36342 \
 		query --update ../sparql/inject-subset-declaration.ru --update ../sparql/inject-synonymtype-declaration.ru \
@@ -43,9 +43,9 @@ $(IMPORTDIR)/chebi_import.owl: $(MIRRORDIR)/chebi.owl $(IMPORTDIR)/chebi_terms_c
 ## We need to use the ODK default ROBOT 'extract' method plus 'filter' in here to remove out-of-scope terms that 
 ## get also pulled in. And we remove the NCBITaxon intermediates between OBI:organism and NCBITaxon:Homo Sapiens.
 
-$(IMPORTDIR)/obi_import.owl: $(MIRRORDIR)/obi.owl $(IMPORTDIR)/obi_terms_combined.txt
+$(IMPORTDIR)/obi_import.owl: $(MIRRORDIR)/obi.owl $(IMPORTDIR)/obi_terms.txt
 	if [ $(IMP) = true ]; then $(ROBOT) query -i $< --update ../sparql/preprocess-module.ru \
-		extract -T $(IMPORTDIR)/obi_terms_combined.txt --copy-ontology-annotations true --force true \
+		extract -T $(IMPORTDIR)/obi_terms.txt --copy-ontology-annotations true --force true \
 		    --individuals include --method BOT \
 		remove --term OBI:0100026 --select "descendants" --exclude-term NCBITaxon:9606 \
 		remove -T $(IMPORTDIR)/obi_terms_to_remove.txt --select "self instances descendants" \


### PR DESCRIPTION
After upgrading to ODK v1.6, the QC workflow began failing because custom import module rules (obi, ms, chebi) listed mirror files as hard prerequisites. When `MIR=false` in the test pipeline, make would fail trying to satisfy these prerequisites before the rule body's `if [ $(IMP) = true ]` guard could execute.

Hence, this PR removes mirror files from the prerequisite line in the custom rules. They're still referenced inside the rule body when needed, but make no longer requires them to exist upfront. This allows the workflow to correctly skip import generation when `IMP=false`.